### PR TITLE
1649: Changed site name and slogan

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -1,7 +1,7 @@
 uuid: 112dba9d-c538-4c1b-be11-42111dd60921
-name: Drupal
-mail: ''
-slogan: ''
+name: 'Debug Academy Drupal Project'
+mail: wendy@debugacademy.com
+slogan: 'Where Drupal Comes Alive!'
 page:
   403: ''
   404: ''


### PR DESCRIPTION
Web Developer Notes:
1. Changed site name, slogan and email. The reasoning was because we wanted to demonstrate how to start a new task and do a simple change on the website.